### PR TITLE
fix(cli): count only WARN/ERROR as doctor findings

### DIFF
--- a/internal/cli/cmd_doctor.go
+++ b/internal/cli/cmd_doctor.go
@@ -79,8 +79,21 @@ func countErrors(findings []doctor.Finding) int {
 	return errs
 }
 
+// countFindings tallies rows that need attention (WARN or ERROR). PASS is a
+// check result, not a finding; counting it made a clean doctor run look dirty.
+func countFindings(findings []doctor.Finding) int {
+	n := 0
+	for _, f := range findings {
+		if f.Level == "WARN" || f.Level == "ERROR" {
+			n++
+		}
+	}
+	return n
+}
+
 // renderDoctor prints the text form: one line per finding, an indented
-// fix: line when present, and a one-line summary.
+// fix: line when present, and a one-line summary. The summary counts only
+// WARN/ERROR as findings; an all-PASS run reports checks and "all PASS".
 func renderDoctor(w io.Writer, findings []doctor.Finding, errs int) {
 	for _, f := range findings {
 		fmt.Fprintf(w, "%-5s %s: %s\n", f.Level, f.Check+" "+f.Slug, f.Message)
@@ -88,5 +101,9 @@ func renderDoctor(w io.Writer, findings []doctor.Finding, errs int) {
 			fmt.Fprintf(w, "      fix: %s\n", f.Fix)
 		}
 	}
-	fmt.Fprintf(w, "takt doctor: %d finding(s), %d error(s)\n", len(findings), errs)
+	if n := countFindings(findings); n == 0 {
+		fmt.Fprintf(w, "takt doctor: %d check(s), all PASS\n", len(findings))
+	} else {
+		fmt.Fprintf(w, "takt doctor: %d finding(s), %d error(s)\n", n, errs)
+	}
 }

--- a/internal/cli/cmd_doctor_summary_test.go
+++ b/internal/cli/cmd_doctor_summary_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/monrad/takt/internal/doctor"
+)
+
+func TestCountFindingsAndRenderSummary(t *testing.T) {
+	t.Parallel()
+	passOnly := []doctor.Finding{
+		{Level: "PASS", Check: "index-lock", Message: "no stranded index.lock"},
+		{Level: "PASS", Check: "state-schema", Slug: "demo", Message: "ok"},
+	}
+	if n := countFindings(passOnly); n != 0 {
+		t.Fatalf("PASS-only findings = %d, want 0", n)
+	}
+	var buf bytes.Buffer
+	renderDoctor(&buf, passOnly, 0)
+	got := buf.String()
+	if !strings.Contains(got, "2 check(s), all PASS") {
+		t.Fatalf("clean summary = %q", got)
+	}
+	if strings.Contains(got, "finding(s)") {
+		t.Fatalf("clean summary must not say finding(s): %q", got)
+	}
+
+	mixed := []doctor.Finding{
+		{Level: "PASS", Check: "state-schema", Slug: "demo", Message: "ok"},
+		{Level: "WARN", Check: "session", Slug: "demo", Message: "stale"},
+		{Level: "ERROR", Check: "plan-disjoint", Slug: "demo", Message: "overlap", Fix: "edit plan"},
+	}
+	if n := countFindings(mixed); n != 2 {
+		t.Fatalf("mixed findings = %d, want 2", n)
+	}
+	if e := countErrors(mixed); e != 1 {
+		t.Fatalf("errors = %d, want 1", e)
+	}
+	buf.Reset()
+	renderDoctor(&buf, mixed, 1)
+	got = buf.String()
+	if !strings.Contains(got, "2 finding(s), 1 error(s)") {
+		t.Fatalf("mixed summary = %q", got)
+	}
+	if strings.Contains(got, "all PASS") {
+		t.Fatalf("mixed summary must not say all PASS: %q", got)
+	}
+	if !strings.Contains(got, "fix: edit plan") {
+		t.Fatalf("missing fix line: %q", got)
+	}
+}

--- a/internal/cli/cmd_doctor_test.go
+++ b/internal/cli/cmd_doctor_test.go
@@ -23,8 +23,16 @@ func TestDoctorTextAndExitCode(t *testing.T) {
 	if code := cli.Main([]string{"doctor"}, &out, &out, getenv, root); code != 0 {
 		t.Fatalf("healthy repo: exit %d\n%s", code, out.String())
 	}
-	if !strings.Contains(out.String(), "PASS  state-schema") {
-		t.Fatalf("output = %s", out.String())
+	got := out.String()
+	if !strings.Contains(got, "PASS  state-schema") {
+		t.Fatalf("output = %s", got)
+	}
+	// Clean run: PASS rows are checks, not findings (#34).
+	if strings.Contains(got, "finding(s)") {
+		t.Fatalf("healthy summary must not count PASS as findings: %s", got)
+	}
+	if !strings.Contains(got, "all PASS") {
+		t.Fatalf("healthy summary want all PASS, got: %s", got)
 	}
 	testutil.WriteFile(t, root, "docs/takt/demo/plan.index.json", `{"schema":1,"spec_hash":"x","tasks":[
 	  {"id":1,"title":"a","description":"d","files":["a.go"],"verify":["true"]},
@@ -33,11 +41,18 @@ func TestDoctorTextAndExitCode(t *testing.T) {
 	if code := cli.Main([]string{"doctor"}, &out, &out, getenv, root); code != 1 {
 		t.Fatalf("overlap: exit %d\n%s", code, out.String())
 	}
-	if !strings.Contains(out.String(), "ERROR plan-disjoint") || !strings.Contains(out.String(), "fix:") {
-		t.Fatalf("output = %s", out.String())
+	got = out.String()
+	if !strings.Contains(got, "ERROR plan-disjoint") || !strings.Contains(got, "fix:") {
+		t.Fatalf("output = %s", got)
 	}
-	code, got, _ := runIn(t, root, nil, "doctor", "--json")
-	if code != 1 || got["errors"] != float64(1) {
-		t.Fatalf("--json: %d %v", code, got)
+	if !strings.Contains(got, "finding(s)") || !strings.Contains(got, "error(s)") {
+		t.Fatalf("ERROR run summary want findings/errors counts: %s", got)
+	}
+	if strings.Contains(got, "all PASS") {
+		t.Fatalf("ERROR run must not say all PASS: %s", got)
+	}
+	code, jgot, _ := runIn(t, root, nil, "doctor", "--json")
+	if code != 1 || jgot["errors"] != float64(1) {
+		t.Fatalf("--json: %d %v", code, jgot)
 	}
 }


### PR DESCRIPTION
## Summary

`takt doctor` summarized every check row as a "finding", so a healthy workspace with only PASS lines (e.g. `PASS index-lock`) printed:

```
takt doctor: 1 finding(s), 0 error(s)
```

That reads as if something needs attention.

## Fix

- Count only **WARN** and **ERROR** rows as findings.
- When every check is PASS, print `takt doctor: N check(s), all PASS`.
- Keep the existing `N finding(s), M error(s)` form when there is anything to fix.

## Test plan

- [x] `TestCountFindingsAndRenderSummary` covers PASS-only and mixed WARN/ERROR summaries.
- [x] Extended `TestDoctorTextAndExitCode` assertions for clean vs ERROR summary wording (full CLI suite needs a git workspace; Linux CI).

Fixes #34
